### PR TITLE
Rebuild evolution class

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/pokemon/Evolution.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Evolution.java
@@ -16,36 +16,38 @@
 package com.pokegoapi.api.pokemon;
 
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
+import POGOProtos.Settings.Master.Pokemon.EvolutionBranchOuterClass.EvolutionBranch;
 import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import com.pokegoapi.main.PokemonMeta;
 
 public class Evolution {
 	@Getter
-	private PokemonId[] parents;
+	private PokemonId parent;
 	@Getter
 	private PokemonId pokemon;
 	@Getter
 	private List<PokemonId> evolutions = new ArrayList<>();
+	@Getter
+	private List<EvolutionBranch> evolutionBranch;
 
 	/**
 	 * Constructor for this evolution class
 	 *
-	 * @param parents the parents of this evolution
-	 * @param pokemon the pokmon being evolved
+	 * @param parent the parent of this evolution
+	 * @param pokemon the pokemon being evolved
 	 */
-	public Evolution(PokemonId[] parents, PokemonId pokemon) {
-		this.parents = parents;
+	public Evolution(PokemonId parent, PokemonId pokemon) {
+		this.parent = parent;
 		this.pokemon = pokemon;
-	}
-
-	/**
-	 * Adds the given pokemon as an evolution
-	 *
-	 * @param pokemon the pokemon to add
-	 */
-	public void addEvolution(PokemonId pokemon) {
-		this.evolutions.add(pokemon);
+		this.evolutionBranch = PokemonMeta.getPokemonSettings(pokemon).getEvolutionBranchList();
+		for (EvolutionBranch evolutionBranch : this.evolutionBranch) {
+			this.evolutions.add(evolutionBranch.getEvolution());
+		}
+		
 	}
 }

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Evolutions.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Evolutions.java
@@ -15,15 +15,14 @@
 
 package com.pokegoapi.api.pokemon;
 
-import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
-import POGOProtos.Networking.Responses.DownloadItemTemplatesResponseOuterClass.DownloadItemTemplatesResponse.ItemTemplate;
-import POGOProtos.Settings.Master.PokemonSettingsOuterClass.PokemonSettings;
-import com.pokegoapi.main.PokemonMeta;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
+import POGOProtos.Networking.Responses.DownloadItemTemplatesResponseOuterClass.DownloadItemTemplatesResponse.ItemTemplate;
+import POGOProtos.Settings.Master.PokemonSettingsOuterClass.PokemonSettings;
 
 public class Evolutions {
 	private static final Map<PokemonId, Evolution> EVOLUTIONS = new HashMap<>();
@@ -38,25 +37,26 @@ public class Evolutions {
 		for (ItemTemplate template : templates) {
 			if (template.hasPokemonSettings()) {
 				PokemonSettings settings = template.getPokemonSettings();
-				PokemonId[] parents = {};
 				PokemonId pokemon = settings.getPokemonId();
-				if (settings.getParentPokemonId() != null) {
-					PokemonSettings parentSettings = PokemonMeta.getPokemonSettings(settings.getParentPokemonId());
-					List<PokemonId> parentEvolutions = parentSettings != null ? parentSettings.getEvolutionIdsList()
-							: null;
-					if (parentEvolutions != null && parentEvolutions.contains(pokemon)) {
-						parents = new PokemonId[]{settings.getParentPokemonId()};
-					}
-				}
-				Evolution evolution = new Evolution(parents, pokemon);
-				EVOLUTIONS.put(pokemon, evolution);
-				for (PokemonId parent : parents) {
-					Evolution parentEvolution = EVOLUTIONS.get(parent);
-					if (parentEvolution != null) {
-						parentEvolution.addEvolution(pokemon);
-					}
+				if(!EVOLUTIONS.containsKey(pokemon))
+				{
+					addEvolution(null, pokemon);
 				}
 			}
+		}
+	}
+	
+	/**
+	 * Returns the evolution data for the given pokemon
+	 *
+	 * @param pokemon the pokemon to get data for
+	 * @return the evolution data
+	 */
+	private static void addEvolution(PokemonId parent, PokemonId pokemon) {
+		Evolution evolution = new Evolution(parent, pokemon);
+		EVOLUTIONS.put(pokemon, evolution);
+		for (PokemonId poke : evolution.getEvolutions()) {
+			addEvolution(pokemon, poke);
 		}
 	}
 
@@ -94,10 +94,8 @@ public class Evolutions {
 		List<PokemonId> basic = new ArrayList<>();
 		Evolution evolution = getEvolution(pokemon);
 		if (evolution != null) {
-			if (evolution.getParents() != null) {
-				for (PokemonId parent : evolution.getParents()) {
-					basic.addAll(getBasic(parent));
-				}
+			if (evolution.getParent() != null) {
+				basic.add(evolution.getParent());
 			} else {
 				basic.add(pokemon);
 			}

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Evolutions.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Evolutions.java
@@ -38,8 +38,7 @@ public class Evolutions {
 			if (template.hasPokemonSettings()) {
 				PokemonSettings settings = template.getPokemonSettings();
 				PokemonId pokemon = settings.getPokemonId();
-				if(!EVOLUTIONS.containsKey(pokemon))
-				{
+				if (!EVOLUTIONS.containsKey(pokemon)) {
 					addEvolution(null, pokemon);
 				}
 			}
@@ -47,10 +46,10 @@ public class Evolutions {
 	}
 	
 	/**
-	 * Returns the evolution data for the given pokemon
+	 * Auxiliar method to add the evolution by recursion in the EVOLUTIONS Map
 	 *
-	 * @param pokemon the pokemon to get data for
-	 * @return the evolution data
+	 * @param parent the parent of this pokemon
+	 * @param pokemon the pokemon that evolution will be added
 	 */
 	private static void addEvolution(PokemonId parent, PokemonId pokemon) {
 		Evolution evolution = new Evolution(parent, pokemon);

--- a/library/src/main/java/com/pokegoapi/api/pokemon/PokemonDetails.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/PokemonDetails.java
@@ -239,9 +239,9 @@ public class PokemonDetails {
 	}
 
 	/**
-	 * Checks whether the Pokémon is set as favorite.
+	 * Checks whether the Pokemon is set as favorite.
 	 *
-	 * @return true if the Pokémon is set as favorite
+	 * @return true if the Pokemon is set as favorite
 	 */
 	public boolean isFavorite() {
 		return favorite > 0;
@@ -272,9 +272,13 @@ public class PokemonDetails {
 		return getSettings().getEncounter().getBaseCaptureRate();
 	}
 
+	/**
+	 * Return the amount of candies necessary to evolve this pokemon
+	 * @return candy needed to evolve
+	 */
 	public int getCandiesToEvolve() {
 		Evolution evolution = Evolutions.getEvolution(pokemonId);
-		if(evolution.getEvolutionBranch()!=null && evolution.getEvolutionBranch().size()>0) {
+		if (evolution.getEvolutionBranch() != null && evolution.getEvolutionBranch().size() > 0) {
 			return evolution.getEvolutionBranch().get(0).getCandyCost();
 		}
 		return 0;

--- a/library/src/main/java/com/pokegoapi/api/pokemon/PokemonDetails.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/PokemonDetails.java
@@ -6,8 +6,12 @@ import POGOProtos.Enums.PokemonFamilyIdOuterClass;
 import POGOProtos.Enums.PokemonIdOuterClass;
 import POGOProtos.Enums.PokemonMoveOuterClass.PokemonMove;
 import POGOProtos.Inventory.Item.ItemIdOuterClass.ItemId;
+import POGOProtos.Settings.Master.Pokemon.EvolutionBranchOuterClass.EvolutionBranch;
 import POGOProtos.Settings.Master.Pokemon.StatsAttributesOuterClass;
 import POGOProtos.Settings.Master.PokemonSettingsOuterClass;
+
+import java.util.List;
+
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.exceptions.NoSuchItemException;
 import com.pokegoapi.main.PokemonMeta;
@@ -269,7 +273,16 @@ public class PokemonDetails {
 	}
 
 	public int getCandiesToEvolve() {
-		return getSettings().getCandyToEvolve();
+		Evolution evolution = Evolutions.getEvolution(pokemonId);
+		if(evolution.getEvolutionBranch()!=null && evolution.getEvolutionBranch().size()>0) {
+			return evolution.getEvolutionBranch().get(0).getCandyCost();
+		}
+		return 0;
+	}
+	
+	public List<EvolutionBranch> getEvolutionBranch() {
+		Evolution evolution = Evolutions.getEvolution(pokemonId);
+		return evolution.getEvolutionBranch();
 	}
 
 	public double getBaseFleeRate() {


### PR DESCRIPTION
**Changes made:**

* Since gen 2 came up, Niantic stopped using some field that is the base of this class to work like ParentId. So what I did is changed the way we initialize Evolutions class to be consistent with the new evolution_branch introduced by game_master files. 
* With the fixing of the above class, I corrected the candyToEvolve too as this field also has not been used anymore in the game_master file.